### PR TITLE
Update dependencies to match aws-iot-device-sdk 1.19.1; stop limiting port to 16 bits

### DIFF
--- a/event-stream-rpc-client/build.gradle.kts
+++ b/event-stream-rpc-client/build.gradle.kts
@@ -25,13 +25,13 @@ tasks.withType<JavaCompile> {
 
 dependencies {
     implementation(project(":event-stream-rpc-model"))
-    implementation("com.google.code.gson:gson:2.8.6")
-    implementation("software.amazon.awssdk.crt:aws-crt:0.16.14")
+    implementation("com.google.code.gson:gson:2.9.0")
+    implementation("software.amazon.awssdk.crt:aws-crt:0.29.9")
 
-    testImplementation("org.json:json:20200518")
-    testCompileOnly("org.junit.jupiter:junit-jupiter-api:5.4.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.0")
-    testCompileOnly("org.junit.jupiter:junit-jupiter-params:5.4.0")
+    testImplementation("org.json:json:20231013")
+    testCompileOnly("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+    testCompileOnly("org.junit.jupiter:junit-jupiter-params:5.8.1")
     testImplementation("org.junit.platform:junit-platform-console-standalone:1.7.0")
     testRuntimeOnly("org.slf4j:slf4j-jdk14:1.7.30")
 

--- a/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCConnection.java
+++ b/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCConnection.java
@@ -94,7 +94,7 @@ public class EventStreamRPCConnection implements AutoCloseable {
         }
         final CompletableFuture<Void> initialConnectFuture = new CompletableFuture<>();
 
-        ClientConnection.connect(config.getHost(), (short) config.getPort(), config.getSocketOptions(),
+        ClientConnection.connect(config.getHost(), config.getPort(), config.getSocketOptions(),
                 config.getTlsContext(), config.getClientBootstrap(), new ClientConnectionHandler() {
                     @Override
                     protected void onConnectionSetup(final ClientConnection clientConnection, int errorCode) {

--- a/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCConnectionConfig.java
+++ b/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCConnectionConfig.java
@@ -57,9 +57,6 @@ public class EventStreamRPCConnectionConfig {
         this.port = port;
         this.connectMessageAmender = connectMessageAmender;
 
-        //perform cast to throw exception here if port value is out of short value range
-        final short shortPort = (short)port;
-
         //bit of C++ RAII here, validate what we can
         if (clientBootstrap == null || eventLoopGroup == null || socketOptions == null ||
             host == null || host.isEmpty() || port < 0) {

--- a/event-stream-rpc-model/build.gradle.kts
+++ b/event-stream-rpc-model/build.gradle.kts
@@ -27,13 +27,13 @@ tasks.withType<JavaCompile> {
 }
 
 dependencies {
-    testImplementation("org.json:json:20200518")
-    implementation("com.google.code.gson:gson:2.8.6")
-    implementation("software.amazon.awssdk.crt:aws-crt:0.16.14")
+    testImplementation("org.json:json:20231013")
+    implementation("com.google.code.gson:gson:2.9.0")
+    implementation("software.amazon.awssdk.crt:aws-crt:0.29.9")
 
-    testCompileOnly("org.junit.jupiter:junit-jupiter-api:5.4.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.0")
-    testCompileOnly("org.junit.jupiter:junit-jupiter-params:5.4.0")
+    testCompileOnly("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+    testCompileOnly("org.junit.jupiter:junit-jupiter-params:5.8.1")
     testRuntimeOnly("org.slf4j:slf4j-jdk14:1.7.30")
 
     testImplementation(project(":test-model-codegen"))

--- a/event-stream-rpc-server/build.gradle.kts
+++ b/event-stream-rpc-server/build.gradle.kts
@@ -25,13 +25,13 @@ tasks.withType<JavaCompile> {
 
 dependencies {
     implementation(project(":event-stream-rpc-model"))
-    implementation("com.google.code.gson:gson:2.8.6")
-    implementation("software.amazon.awssdk.crt:aws-crt:0.16.14")
+    implementation("com.google.code.gson:gson:2.9.0")
+    implementation("software.amazon.awssdk.crt:aws-crt:0.29.9")
     implementation("org.slf4j:slf4j-api:1.7.30")
 
-    testCompileOnly("org.junit.jupiter:junit-jupiter-api:5.4.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.0")
-    testCompileOnly("org.junit.jupiter:junit-jupiter-params:5.4.0")
+    testCompileOnly("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+    testCompileOnly("org.junit.jupiter:junit-jupiter-params:5.8.1")
 
     //pull in server for tests
     testImplementation(project(":test-model-codegen"))

--- a/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/RpcServer.java
+++ b/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/RpcServer.java
@@ -71,7 +71,7 @@ public class RpcServer implements AutoCloseable {
         }
         serverBootstrap = new ServerBootstrap(eventLoopGroup);
         tlsContext = tlsContextOptions != null ? new ServerTlsContext(tlsContextOptions) : null;
-        listener = new ServerListener(hostname, (short) port, socketOptions, tlsContext, serverBootstrap, new ServerListenerHandler() {
+        listener = new ServerListener(hostname, port, socketOptions, tlsContext, serverBootstrap, new ServerListenerHandler() {
                 @Override
                 public ServerConnectionHandler onNewConnection(ServerConnection serverConnection, int errorCode) {
                     try {

--- a/greengrass-client/build.gradle.kts
+++ b/greengrass-client/build.gradle.kts
@@ -56,8 +56,8 @@ dependencies {
     implementation(project(":event-stream-rpc-model"))
     implementation(project(":event-stream-rpc-client"))
 
-    implementation("software.amazon.awssdk.crt:aws-crt:0.16.14")
-    implementation("com.google.code.gson:gson:2.8.6")
+    implementation("com.google.code.gson:gson:2.9.0")
+    implementation("software.amazon.awssdk.crt:aws-crt:0.29.9")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/greengrass-server/build.gradle.kts
+++ b/greengrass-server/build.gradle.kts
@@ -55,8 +55,8 @@ dependencies {
     implementation(project(":event-stream-rpc-model"))
     implementation(project(":event-stream-rpc-server"))
 
-    implementation("software.amazon.awssdk.crt:aws-crt:0.16.14")
-    implementation("com.google.code.gson:gson:2.8.6")
+    implementation("com.google.code.gson:gson:2.9.0")
+    implementation("software.amazon.awssdk.crt:aws-crt:0.29.9")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/import-spec.ini
+++ b/import-spec.ini
@@ -1,8 +1,8 @@
 # sdk version to build from
-SDK_VERSION=1.12.1
+SDK_VERSION=1.19.1
 
 # target sdk version to deploy
-TARGET_VERSION=1.12.2-CLI-SNAPSHOT
+TARGET_VERSION=1.19.1-CLI-SNAPSHOT
 
 #Python sdk to build on top of
 PYTHON_SDK_VERSION=1.6.1

--- a/smithy-event-stream-rpc-cpp/build.gradle.kts
+++ b/smithy-event-stream-rpc-cpp/build.gradle.kts
@@ -30,8 +30,8 @@ dependencies {
     implementation("org.jsoup:jsoup:1.13.1")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.0.2,1.1.0[")
 
-    testCompileOnly("org.junit.jupiter:junit-jupiter-api:5.4.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.0")
-    testCompileOnly("org.junit.jupiter:junit-jupiter-params:5.4.0")
+    testCompileOnly("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+    testCompileOnly("org.junit.jupiter:junit-jupiter-params:5.8.1")
     testCompileOnly("org.hamcrest:hamcrest:2.1")
 }

--- a/smithy-event-stream-rpc-java/build.gradle.kts
+++ b/smithy-event-stream-rpc-java/build.gradle.kts
@@ -30,8 +30,8 @@ dependencies {
     implementation("org.jsoup:jsoup:1.13.1")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.0.2,1.1.0[")
 
-    testCompileOnly("org.junit.jupiter:junit-jupiter-api:5.4.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.0")
-    testCompileOnly("org.junit.jupiter:junit-jupiter-params:5.4.0")
+    testCompileOnly("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+    testCompileOnly("org.junit.jupiter:junit-jupiter-params:5.8.1")
     testCompileOnly("org.hamcrest:hamcrest:2.1")
 }

--- a/smithy-event-stream-rpc-javascript/build.gradle.kts
+++ b/smithy-event-stream-rpc-javascript/build.gradle.kts
@@ -30,8 +30,8 @@ dependencies {
     implementation("org.jsoup:jsoup:1.13.1")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.0.2,1.1.0[")
 
-    testCompileOnly("org.junit.jupiter:junit-jupiter-api:5.4.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.0")
-    testCompileOnly("org.junit.jupiter:junit-jupiter-params:5.4.0")
+    testCompileOnly("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+    testCompileOnly("org.junit.jupiter:junit-jupiter-params:5.8.1")
     testCompileOnly("org.hamcrest:hamcrest:2.1")
 }

--- a/smithy-event-stream-rpc-python/build.gradle.kts
+++ b/smithy-event-stream-rpc-python/build.gradle.kts
@@ -30,8 +30,8 @@ dependencies {
     implementation("org.jsoup:jsoup:1.13.1")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.0.2,1.1.0[")
 
-    testCompileOnly("org.junit.jupiter:junit-jupiter-api:5.4.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.0")
-    testCompileOnly("org.junit.jupiter:junit-jupiter-params:5.4.0")
+    testCompileOnly("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+    testCompileOnly("org.junit.jupiter:junit-jupiter-params:5.8.1")
     testCompileOnly("org.hamcrest:hamcrest:2.1")
 }

--- a/test-model-codegen/build.gradle.kts
+++ b/test-model-codegen/build.gradle.kts
@@ -42,12 +42,12 @@ dependencies {
     implementation(project(":event-stream-rpc-client"))
     implementation(project(":event-stream-rpc-server"))
 
-    compileOnly("org.junit.jupiter:junit-jupiter-api:5.4.0")
-    compileOnly("org.junit.jupiter:junit-jupiter-params:5.4.0")
-    runtimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.0")
+    compileOnly("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    compileOnly("org.junit.jupiter:junit-jupiter-params:5.8.1")
+    runtimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
 
-    implementation("software.amazon.awssdk.crt:aws-crt:0.16.14")
-    implementation("com.google.code.gson:gson:2.8.6")
+    implementation("com.google.code.gson:gson:2.9.0")
+    implementation("software.amazon.awssdk.crt:aws-crt:0.29.9")
 }
 
 java {


### PR DESCRIPTION
*Issue #, if available:*

Related to https://github.com/awslabs/aws-c-io/issues/576

*Description of changes:*

Update dependencies to match aws-iot-device-sdk 1.19.1: https://mvnrepository.com/artifact/software.amazon.awssdk.iotdevicesdk/aws-iot-device-sdk/1.19.1

This includes a change to stop limiting port numbers to 16 bits (now 32 bits).

Verified by the tests passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
