### PR TITLE
Add ComponentName field to UpdateConfigurationRequest

### DIFF
--- a/greengrass-ipc-model/main.smithy
+++ b/greengrass-ipc-model/main.smithy
@@ -444,6 +444,8 @@ structure GetConfigurationResponse {
 }
 
 structure UpdateConfigurationRequest {
+    /// (Optional) The name of the component. Defaults to the name of the component that makes the request.
+    componentName: String,
     /// (Optional) The key path to the container node (the object) to update. Specify a list where each entry is the key for a single level in the configuration object. Defaults to the root of the configuration object.
     keyPath: KeyPath,
     /// The current Unix epoch time in milliseconds. This operation uses this timestamp to resolve concurrent updates to the key. If the key in the component configuration has a greater timestamp than the timestamp in the request, then the request fails.


### PR DESCRIPTION
Hello, I'm creating this PR early for visibility and review. This PR is not ready to merge yet.

*Issue #, if available:*
GG-44915

*Description of changes*

Adding in an optional ComponentName field to UpdateConfigurationRequest.

For this user story: As a developer building components to run in Greengrass, I want to update a component A's config from an other component B, so that B can adjust the behavior of A at runtime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
