### PR TITLE
Generate java sources with copyright header

### DIFF
--- a/export.sh
+++ b/export.sh
@@ -35,18 +35,6 @@ projections=(greengrass-client)
 
 repo=$workspace/${PREFIX}aws-iot-device-sdk-java-v2
 
-# Java-v2 - add generated comment and copyright text
-for entry in `find ./greengrass-client/build/smithyprojections/greengrass-client/source/event-stream-rpc-java -type f`; do
-    if [[ $entry =~ \.java$ ]]; then # only do .java files
-        printf "/**\n * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n * SPDX-License-Identifier: Apache-2.0.\n *\n * This file is generated.\n */\n\n" | cat - $entry > temp && mv temp $entry
-    fi
-done
-for entry in `find ./greengrass-server/build/smithyprojections/greengrass-server/source/event-stream-rpc-java -type f`; do
-    if [[ $entry =~ \.java$ ]]; then # only do .java files
-        printf "/**\n * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n * SPDX-License-Identifier: Apache-2.0.\n *\n * This file is generated.\n */\n\n" | cat - $entry > temp && mv temp $entry
-    fi
-done
-
 # Java-v2 - copy files (first greengrass then event-stream-rpc)
 for pkg in "${libs[@]}"; do
     mkdir -p ${repo}/sdk/greengrass/${pkg}/src/main/java

--- a/smithy-event-stream-rpc-java/src/main/java/software/amazon/smithy/eventstreamrpc/java/JavaCodegenPlugin.java
+++ b/smithy-event-stream-rpc-java/src/main/java/software/amazon/smithy/eventstreamrpc/java/JavaCodegenPlugin.java
@@ -21,6 +21,13 @@ public class JavaCodegenPlugin implements SmithyBuildPlugin {
 
     public static final String SMITHY_NAMESPACE_PREFIX = "smithy";
 
+    public static final String COPYRIGHT_FILE_HEADER = "/**\n"
+        + " * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n"
+        + " * SPDX-License-Identifier: Apache-2.0.\n"
+        + " *\n"
+        + " * This file is generated.\n"
+        + " */\n\n";
+
     @Override
     public String getName() {
         return "event-stream-rpc-java";
@@ -53,23 +60,18 @@ public class JavaCodegenPlugin implements SmithyBuildPlugin {
 
         //go through every generator and add it's files to the manifest and write them out
         generators.forEach(generator -> generator.accept(outputFile -> {
-                try {
-                    if (pluginContext.getFileManifest().getBaseDir().resolve(
-                            generator.getOutputSubdirectory()).resolve(outputFile.toJavaFileObject().getName())
-                                .toFile().exists()) {
-                        LOGGER.warning("Writing to an already existing file: " +
-                                pluginContext.getFileManifest().getBaseDir().resolve(
-                                        generator.getOutputSubdirectory()).resolve(outputFile.toJavaFileObject().getName())
-                                        .toAbsolutePath().toString() + ". Check code generation logic if generation output dir was cleaned first");
-                    } else {
-                        final Path fileOutput = outputFile.writeToPath(
-                                pluginContext.getFileManifest().getBaseDir().resolve(generator.getOutputSubdirectory()));
-                        pluginContext.getFileManifest().addFile(fileOutput);
-                        LOGGER.info("File created: " + fileOutput.toAbsolutePath().toString());
-                    }
-
-                } catch (IOException e) {
-                    throw new CodegenException(e);
+                if (pluginContext.getFileManifest().getBaseDir().resolve(
+                        generator.getOutputSubdirectory()).resolve(outputFile.toJavaFileObject().getName())
+                            .toFile().exists()) {
+                    LOGGER.warning("Writing to an already existing file: " +
+                            pluginContext.getFileManifest().getBaseDir().resolve(
+                                    generator.getOutputSubdirectory()).resolve(outputFile.toJavaFileObject().getName())
+                                    .toAbsolutePath().toString() + ". Check code generation logic if generation output dir was cleaned first");
+                } else {
+                    String fileContent = outputFile.toString();
+                    Path filename = pluginContext.getFileManifest().getBaseDir().resolve(generator.getOutputSubdirectory()).resolve(outputFile.toJavaFileObject().getName());
+                    pluginContext.getFileManifest().writeFile(filename, COPYRIGHT_FILE_HEADER + fileContent);
+                    LOGGER.info("File created: " + filename.toString());
                 }
             }));
     }

--- a/smithy-event-stream-rpc-java/src/main/java/software/amazon/smithy/eventstreamrpc/java/JavaCodegenPlugin.java
+++ b/smithy-event-stream-rpc-java/src/main/java/software/amazon/smithy/eventstreamrpc/java/JavaCodegenPlugin.java
@@ -68,8 +68,13 @@ public class JavaCodegenPlugin implements SmithyBuildPlugin {
                                     generator.getOutputSubdirectory()).resolve(outputFile.toJavaFileObject().getName())
                                     .toAbsolutePath().toString() + ". Check code generation logic if generation output dir was cleaned first");
                 } else {
+                    // The JavaFile class has addFileComment method, but it formats comments in one-line style (i.e. with //).
+                    // The only alternative is to concatenate the copyright comment with generated file content and only then
+                    // write them to the target file.
                     String fileContent = outputFile.toString();
-                    Path filename = pluginContext.getFileManifest().getBaseDir().resolve(generator.getOutputSubdirectory()).resolve(outputFile.toJavaFileObject().getName());
+                    Path filename = pluginContext.getFileManifest().getBaseDir()
+                        .resolve(generator.getOutputSubdirectory())
+                        .resolve(outputFile.toJavaFileObject().getName());
                     pluginContext.getFileManifest().writeFile(filename, COPYRIGHT_FILE_HEADER + fileContent);
                     LOGGER.info("File created: " + filename.toString());
                 }


### PR DESCRIPTION
I verified that generated code didn't changed with the following command:
```
diff -r \
  aws-iot-device-sdk-java-v2/sdk/greengrass/greengrass-client/src/event-stream-rpc-java/ \
  greengrass-client/build/smithyprojections/greengrass-client/source/event-stream-rpc-java/
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
