### PR TITLE
Add special file header for non-generated event-stream sources

### DIFF
--- a/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCClient.java
+++ b/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCClient.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.crt.eventstream.ClientConnectionContinuation;

--- a/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCConnection.java
+++ b/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCConnection.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.crt.CRT;

--- a/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCConnectionConfig.java
+++ b/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCConnectionConfig.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.crt.io.ClientBootstrap;

--- a/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/GreengrassConnectMessageSupplier.java
+++ b/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/GreengrassConnectMessageSupplier.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import com.google.gson.Gson;

--- a/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/GreengrassEventStreamConnectMessage.java
+++ b/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/GreengrassEventStreamConnectMessage.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 /**

--- a/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationResponse.java
+++ b/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationResponse.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.crt.eventstream.ClientConnectionContinuation;

--- a/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/StreamResponse.java
+++ b/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/StreamResponse.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;

--- a/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/StreamResponseHandler.java
+++ b/event-stream-rpc-client/src/main/java/software/amazon/awssdk/eventstreamrpc/StreamResponseHandler.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 /**

--- a/event-stream-rpc-client/src/test/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCClientTests.java
+++ b/event-stream-rpc-client/src/test/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCClientTests.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import org.junit.jupiter.api.Assertions;

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/DeserializationException.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/DeserializationException.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 /**

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamClosedException.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamClosedException.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 /**

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceModel.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceModel.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import com.google.gson.Gson;

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/InvalidDataException.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/InvalidDataException.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.crt.eventstream.MessageType;

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/MessageAmendInfo.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/MessageAmendInfo.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.crt.eventstream.Header;

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationModelContext.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationModelContext.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/SerializationException.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/SerializationException.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 /**

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/StreamEventPublisher.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/StreamEventPublisher.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/UnmappedDataException.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/UnmappedDataException.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/Version.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/Version.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import java.util.Objects;

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/AccessDeniedException.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/AccessDeniedException.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc.model;
 
 /**

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamError.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamError.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc.model;
 
 import com.google.gson.JsonSyntaxException;

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamJsonMessage.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamJsonMessage.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc.model;
 
 import com.google.gson.Gson;

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamOperationError.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/EventStreamOperationError.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc.model;
 
 import com.google.gson.annotations.Expose;

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/InternalServerException.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/InternalServerException.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc.model;
 
 /**

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/UnsupportedOperationException.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/UnsupportedOperationException.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc.model;
 
 /**

--- a/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/ValidationException.java
+++ b/event-stream-rpc-model/src/main/java/software/amazon/awssdk/eventstreamrpc/model/ValidationException.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc.model;
 
 /**

--- a/event-stream-rpc-model/src/test/java/software/amazon/awssdk/eventstreamrpc/ObjectModelTests.java
+++ b/event-stream-rpc-model/src/test/java/software/amazon/awssdk/eventstreamrpc/ObjectModelTests.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import org.json.JSONObject;

--- a/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthenticationData.java
+++ b/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthenticationData.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 /**

--- a/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthenticationHandler.java
+++ b/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthenticationHandler.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.crt.eventstream.Header;

--- a/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/Authorization.java
+++ b/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/Authorization.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 /**

--- a/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthorizationHandler.java
+++ b/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/AuthorizationHandler.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import java.util.function.Function;

--- a/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/DebugLoggingOperationHandler.java
+++ b/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/DebugLoggingOperationHandler.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import com.google.gson.Gson;

--- a/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceHandler.java
+++ b/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/EventStreamRPCServiceHandler.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import java.util.Collection;

--- a/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/InvalidServiceConfigurationException.java
+++ b/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/InvalidServiceConfigurationException.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 /**

--- a/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/IpcServer.java
+++ b/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/IpcServer.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import org.slf4j.Logger;

--- a/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandler.java
+++ b/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandler.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import org.slf4j.Logger;

--- a/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerContext.java
+++ b/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerContext.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.crt.eventstream.ServerConnection;

--- a/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerFactory.java
+++ b/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/OperationContinuationHandlerFactory.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuationHandler;

--- a/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/RpcServer.java
+++ b/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/RpcServer.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import org.slf4j.Logger;

--- a/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/ServiceOperationMappingContinuationHandler.java
+++ b/event-stream-rpc-server/src/main/java/software/amazon/awssdk/eventstreamrpc/ServiceOperationMappingContinuationHandler.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import org.slf4j.Logger;

--- a/event-stream-rpc-server/src/test/java/software/amazon/awssdk/eventstreamrpc/EchoTestServiceTests.java
+++ b/event-stream-rpc-server/src/test/java/software/amazon/awssdk/eventstreamrpc/EchoTestServiceTests.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import org.junit.jupiter.api.Assertions;

--- a/event-stream-rpc-server/src/test/java/software/amazon/awssdk/eventstreamrpc/IpcServerTests.java
+++ b/event-stream-rpc-server/src/test/java/software/amazon/awssdk/eventstreamrpc/IpcServerTests.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* This file is part of greengrass-ipc project. */
+
 package software.amazon.awssdk.eventstreamrpc;
 
 import org.junit.jupiter.api.Assertions;


### PR DESCRIPTION
Event-stream sources are copied as-is to other repos. Since these source files don't have any indication that they're belong to another project, sometimes they're changed outside this repo.

This header will help to prevent changing event-stream sources outside this repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
