### PR TITLE
feat: update GetSecretValueRequest model

### DIFF
--- a/greengrass-ipc-model/main.smithy
+++ b/greengrass-ipc-model/main.smithy
@@ -867,7 +867,9 @@ structure GetSecretValueRequest {
     /// (Optional) The ID of the version to get. If you don't specify versionId or versionStage, this operation defaults to the version with the AWSCURRENT label.
     versionId: String,
     /// (Optional) The staging label of the version to get. If you don't specify versionId or versionStage, this operation defaults to the version with the AWSCURRENT label.
-    versionStage: String
+    versionStage: String,
+    /// (Optional) Whether to fetch the latest secret from cloud when the request is handled. Defaults to false.
+    refresh: Boolean
 }
 
 structure GetSecretValueResponse {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update `GetSecretValueRequest` model to include optional `refresh` parameter. When this is set to True, secret manager component will try to fetch the latest secret from the cloud. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
