### PR TITLE
Remove aws-crt-builder from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.8.12
-  BUILDER_SOURCE: releases
-  BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: smithy-iot-device-sdk-greengrass-ipc
-  LINUX_BASE_IMAGE: ubuntu-18-x64
-  HEAD_REF: ${{ github.head_ref }}
-  RUN: ${{ github.run_id }}-${{ github.run_number }}
-  AWS_DEFAULT_REGION: us-east-1
 
 jobs:
   linux-compat:
@@ -26,19 +19,23 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'corretto'
       - name: Build ${{ env.PACKAGE_NAME }}
-        run: |
-          # TODO Configure credentials to be able to use newer versions of the builder.
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ matrix.image }}:${{ env.BUILDER_VERSION }}
-          docker pull $DOCKER_IMAGE
-          docker run --mount type=bind,source=$(pwd),target=/root/${{ env.PACKAGE_NAME }} --env GITHUB_REF $DOCKER_IMAGE build -p ${{ env.PACKAGE_NAME }}
+        run: ./gradlew build
+
   linux-ubuntu:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'corretto'
       - name: Build ${{ env.PACKAGE_NAME }}
-        run: |
-          python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+        run: ./gradlew build


### PR DESCRIPTION
We do not need the aws-crt-builder in CI. Removing it and replacing with a simple `gradlew build` command.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
