### PR TITLE
feat: add SubscribeToIoTCoreConnectionStatus operation

### DIFF
--- a/greengrass-ipc-model/main.smithy
+++ b/greengrass-ipc-model/main.smithy
@@ -40,7 +40,8 @@ service GreengrassCoreIPC {
         VerifyClientDeviceIdentity,
         GetClientDeviceAuthToken,
         AuthorizeClientDeviceAction,
-        PutComponentMetric
+        PutComponentMetric,
+        SubscribeToIoTCoreConnectionStatus
     ]
 }
 
@@ -191,6 +192,13 @@ operation SubscribeToIoTCore {
     input: SubscribeToIoTCoreRequest,
     output: SubscribeToIoTCoreResponse,
     errors: [ServiceError, UnauthorizedError]
+}
+
+/// Subscribe to the connection status of the IoT Core MQTT connection.
+operation SubscribeToIoTCoreConnectionStatus {
+    input: SubscribeToIoTCoreConnectionStatusRequest,
+    output: SubscribeToIoTCoreConnectionStatusResponse,
+    errors: [ServiceError]
 }
 
 /// Validate authorization token
@@ -1306,3 +1314,33 @@ structure PublishToIoTCoreResponse {}
 structure PauseComponentResponse {}
 structure ResumeComponentResponse {}
 structure PutComponentMetricResponse {}
+
+structure SubscribeToIoTCoreConnectionStatusRequest {}
+
+structure SubscribeToIoTCoreConnectionStatusResponse {
+    connectionStatusEvent: IoTCoreConnectionStatusEvent
+}
+
+@streaming
+union IoTCoreConnectionStatusEvent {
+    /// The connection status event.
+    connectionStatusEvent: ConnectionStatusEvent
+}
+
+structure ConnectionStatusEvent {
+    /// The connection status.
+    @required
+    status: ConnectionStatus
+}
+
+@enum([
+    {
+        value: "CONNECTED",
+        name: "CONNECTED"
+    },
+    {
+        value: "DISCONNECTED",
+        name: "DISCONNECTED"
+    }
+])
+string ConnectionStatus


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add `SubscribeToIoTCoreConnectionStatus` operation to the Greengrass IPC model.
This operation allows components to subscribe to the MQTT connection status
(CONNECTED/DISCONNECTED) of the core device's connection to AWS IoT Core.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.