### PR TITLE
feat(ipc-model): Add subscriptionMode to subscribeToIoTCoreRequest

### DIFF
--- a/greengrass-ipc-model/main.smithy
+++ b/greengrass-ipc-model/main.smithy
@@ -809,9 +809,11 @@ structure SubscribeToIoTCoreRequest {
     /// The topic to which to subscribe. Supports MQTT wildcards.
     @required
     topicName: String,
-    /// The MQTT QoS to use.
-    @required
+    /// The MQTT QoS to use for the cloud subscription. Required when subscriptionMode is SUBSCRIBE_AND_RECEIVE or not set - omitting it causes the request to fail.
+    /// Ignored when subscriptionMode is RECEIVE_ONLY (no cloud subscription is created).
     qos: QOS,
+    /// (Optional) Whether to create a cloud subscription, or only receive messages already delivered to the device. Defaults to SUBSCRIBE_AND_RECEIVE when not set.
+    subscriptionMode: SubscriptionMode
 }
 
 structure SubscribeToIoTCoreResponse {
@@ -1163,6 +1165,18 @@ string PayloadFormat
     }
 ])
 string ReceiveMode
+
+@enum([
+    {
+        value: "SUBSCRIBE_AND_RECEIVE",
+        name: "SUBSCRIBE_AND_RECEIVE"
+    },
+    {
+        value: "RECEIVE_ONLY",
+        name: "RECEIVE_ONLY"
+    }
+])
+string SubscriptionMode
 
 @enum([
     {


### PR DESCRIPTION
### feat(ipc-model): Adding subscriptionMode field and relaxing QoS in SubscribeToIoTCoreRequest
  
  Adding an optional `subscriptionMode` enum field to `SubscribeToIoTCoreRequest`,
  and relaxes `qos` from required to optional.

  - `subscriptionMode: SubscriptionMode` is a new enum, values `SUBSCRIBE | RECEIVE_ONLY`
  - `qos` — removing `@required` attribute to make it optional.

Rationale:
  `RECEIVE_ONLY` selects that local-only behavior.
  `SUBSCRIBE` is the existing behavior to create a cloud subscription. 
  When the field is absent, the request behaves exactly as today.


  ## Behavior mapping
  | subscriptionMode        | Effect                                             |
  |-------------------------|----------------------------------------------------|
  | `SUBSCRIBE`             | Create a cloud subscription (existing behavior)    |
  | `RECEIVE_ONLY`          | do not create a cloud subscription |

  ## Backward compatibility
  This is an additive, non-breaking model change:
  - **Adding an optional field** — When old clients that never send `subscriptionMode`
    deserialize fine; the field arrives absent and is treated as `SUBSCRIBE`.
  - **required → optional on `qos`** — only loosens a rule. Existing messages that
    always sent `qos` still validate.
  - **Unknown enum values degrade safely** — An unrecognized `subscriptionMode`
    string deserializes to `null`.
    
  ## Testing
  - `./gradlew clean build` passes (regenerates all language SDK projections).
  - `test-model-codegen` (PetShop fixture) builds cleanly.