### PR TITLE
Add sensitive field redaction to JavaScript code generator

### DIFF
--- a/smithy-event-stream-rpc-javascript/src/main/java/software/amazon/smithy/eventstreamrpc/javascript/ServiceCodegenContext.java
+++ b/smithy-event-stream-rpc-javascript/src/main/java/software/amazon/smithy/eventstreamrpc/javascript/ServiceCodegenContext.java
@@ -136,6 +136,30 @@ public class ServiceCodegenContext {
         return null;
     }
 
+    /**
+     * A member is treated as sensitive when the {@link SensitiveTrait} is applied to the member itself,
+     * to the shape the member targets, or to the enclosing structure/union.
+     */
+    public boolean isSensitiveMember(Shape enclosingShape, MemberShape memberShape) {
+        if (enclosingShape.hasTrait(SensitiveTrait.class) || memberShape.hasTrait(SensitiveTrait.class)) {
+            return true;
+        }
+        return model.getShape(memberShape.getTarget())
+                .map(target -> target.hasTrait(SensitiveTrait.class))
+                .orElse(false);
+    }
+
+    public boolean hasSensitiveMembers(Shape shape) {
+        return shape.members().stream().anyMatch(memberShape -> isSensitiveMember(shape, memberShape));
+    }
+
+    public List<String> getSensitiveMemberNames(Shape shape) {
+        return shape.members().stream()
+                .filter(memberShape -> isSensitiveMember(shape, memberShape))
+                .map(MemberShape::getMemberName)
+                .collect(Collectors.toList());
+    }
+
     public static String getOperationResponseSuffix() {
         return "Response";
     }

--- a/smithy-event-stream-rpc-javascript/src/main/resources/software/amazon/smithy/eventstreamrpc/javascript/model/model_utils_deserializers.ftl
+++ b/smithy-event-stream-rpc-javascript/src/main/resources/software/amazon/smithy/eventstreamrpc/javascript/model/model_utils_deserializers.ftl
@@ -15,6 +15,9 @@ export function deserialize${className}(value : model.${className}) : model.${cl
     ${context.getDeserializeLine(shapeMember)}
 </#if>
 </#list>
+<#if context.hasSensitiveMembers(downcastShape)>
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, [<#list context.getSensitiveMemberNames(downcastShape) as sensitiveMemberName>'${sensitiveMemberName}'<#sep>, </#sep></#list>]);
+</#if>
     return value;
 }
 

--- a/smithy-event-stream-rpc-javascript/src/main/resources/software/amazon/smithy/eventstreamrpc/javascript/model/model_utils_normalizers.ftl
+++ b/smithy-event-stream-rpc-javascript/src/main/resources/software/amazon/smithy/eventstreamrpc/javascript/model/model_utils_normalizers.ftl
@@ -12,6 +12,9 @@ export function normalize${context.getTypeName(downcastShape)}(value : model.${c
 <#list downcastShapeMembers as shapeMember>
     ${context.getNormalizerMemberLine(shapeMember)}
 </#list>
+<#if context.hasSensitiveMembers(downcastShape)>
+    eventstream_rpc_utils.applySensitiveDataRedaction(value, [<#list context.getSensitiveMemberNames(downcastShape) as sensitiveMemberName>'${sensitiveMemberName}'<#sep>, </#sep></#list>]);
+</#if>
 
     return normalizedValue;
 }

--- a/smithy-event-stream-rpc-javascript/src/main/resources/software/amazon/smithy/eventstreamrpc/javascript/model/model_utils_normalizers.ftl
+++ b/smithy-event-stream-rpc-javascript/src/main/resources/software/amazon/smithy/eventstreamrpc/javascript/model/model_utils_normalizers.ftl
@@ -12,9 +12,6 @@ export function normalize${context.getTypeName(downcastShape)}(value : model.${c
 <#list downcastShapeMembers as shapeMember>
     ${context.getNormalizerMemberLine(shapeMember)}
 </#list>
-<#if context.hasSensitiveMembers(downcastShape)>
-    eventstream_rpc_utils.applySensitiveDataRedaction(value, [<#list context.getSensitiveMemberNames(downcastShape) as sensitiveMemberName>'${sensitiveMemberName}'<#sep>, </#sep></#list>]);
-</#if>
 
     return normalizedValue;
 }


### PR DESCRIPTION

*Description of changes:*
- Adding `sensitive` trait support to the JavaScript event-stream RPC code generator.
- The generator now emits redaction calls for shapes with `sensitive` members in both the deserializer and normalizer paths. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
